### PR TITLE
Removing username from anonymous messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 npm i -S hubot-anon
 ```
 
-Optional set environment variable *HUBOT_ANON_TO* to replace default channel (#random).
+Optional set environment variable *HUBOT_ANON_TO* to replace default channel (#general).
 
 add `["hubot-anon"]` to `external-scripts.json`.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ add `["hubot-anon"]` to `external-scripts.json`.
 
 ## Examples
 
-`hubot anon <message>` -> `Send message to default channel`
+`hubot anon <message>` -> `Send message to the default channel`
 
 `hubot anon <#channel> <message>` -> `Send message to #channel`
 

--- a/src/script.coffee
+++ b/src/script.coffee
@@ -8,7 +8,7 @@
 #   HUBOT_ANON_TO
 #
 # Commands:
-#   hubot anon <message> - Send message to default channel
+#   hubot anon <message> - Send message to the default channel
 #   hubot anon <#channel> <message> - Send message to #channel
 #
 # Author:
@@ -19,14 +19,14 @@ module.exports = (robot) ->
     args = res.match[1].trim().split(/\s+/)
     channel = args[0]
     unless /^#/.test(channel)
-      channel = process.env.HUBOT_ANON_TO or "#random"
+      channel = process.env.HUBOT_ANON_TO or "#general"
     else
       args.shift()
     text = args.join(" ")
     try
       robot.messageRoom(channel, text)
       from = res.message.user.name
-      res.send("""@#{from} send "#{text}" to #{channel}""")
+      res.send("""anonymous message to #{channel}: #{text}""")
     catch err
       res.reply("an error has occurred: #{err.message}")
       robot.emit("error", err)

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -44,5 +44,5 @@ describe "hubot-anon", ->
       expect(@room.messages).to.eql([
         ["user", "hubot anon hello world"]
         ["hubot", "hello world"]
-        ["hubot", """anonymous message to #general: hello world"""]
+        ["hubot", """anonymous message to #default: hello world"""]
       ])

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -15,34 +15,34 @@ describe "hubot-anon", ->
       @room.user.say("user", "hubot anon hello world")
       setTimeout(done, 100)
 
-    it "should get a message in #random", ->
+    it "should get a message in #general", ->
       expect(@room.messages).to.eql([
         ["user", "hubot anon hello world"]
         ["hubot", "hello world"]
-        ["hubot", """@user send "hello world" to #random"""]
+        ["hubot", """anonymous message to #general: hello world"""]
       ])
 
   context "valid channel", ->
     beforeEach (done) ->
-      @room.user.say("user", "hubot anon #general hello world")
+      @room.user.say("user", "hubot anon #random hello world")
       setTimeout(done, 100)
 
-    it "should get a message in #general", ->
+    it "should get a message in #random", ->
       expect(@room.messages).to.eql([
-        ["user", "hubot anon #general hello world"]
+        ["user", "hubot anon #random hello world"]
         ["hubot", "hello world"]
-        ["hubot", """@user send "hello world" to #general"""]
+        ["hubot", """anonymous message to #random: hello world"""]
       ])
 
   context "replace default channel", ->
     beforeEach (done) ->
-      process.env.HUBOT_ANON_TO = "#general"
+      process.env.HUBOT_ANON_TO = "#default"
       @room.user.say("user", "hubot anon hello world")
       setTimeout(done, 100)
 
-    it "should get a message in #general", ->
+    it "should get a message in #default", ->
       expect(@room.messages).to.eql([
         ["user", "hubot anon hello world"]
         ["hubot", "hello world"]
-        ["hubot", """@user send "hello world" to #general"""]
+        ["hubot", """anonymous message to #general: hello world"""]
       ])


### PR DESCRIPTION
While using the script, I noticed that the posted messages contain the username of the sender, that seems contrary to an anonymous message.
I propose to remove the username from the message. I also changed the default channel to #general to point to the default channel out-of-the-box on a fresh rocketchat instance.